### PR TITLE
Attempt to access CLLocationManager.location immediately

### DIFF
--- a/Source/CLLocationManager+ClosureKit.swift
+++ b/Source/CLLocationManager+ClosureKit.swift
@@ -71,6 +71,9 @@ extension CLLocationManager: CLLocationManagerDelegate {
         self.closureWrapper = ClosureWrapper(handler: completion)
         self.delegate = self
         self.startUpdatingLocation()
+        if let location = self.location {
+            completion(location)
+        }
     }
 
     /**


### PR DESCRIPTION
Attempt to access CLLocationManager.location immediately. This allows us to know our current location sooner, by 20-200+ms. Typically, the savings was ~100ms on both iPhone 5S and 6.
