### PR TITLE
rename NSTimer convenient method

### DIFF
--- a/ClosureKit.podspec
+++ b/ClosureKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ClosureKit'
-  s.version = '0.0.1'
+  s.version = '0.0.2'
   s.license = 'MIT'
   s.summary = 'Closures on most used UIKit methods'
   s.homepage = 'https://github.com/Reflejo/ClosureKit'

--- a/Source/NSTimer+ClosureKit.swift
+++ b/Source/NSTimer+ClosureKit.swift
@@ -49,12 +49,12 @@ extension NSTimer {
 
     :returns: a new NSTimer object, configured according to the specified parameters.
     */
-    class public func scheduledTimerWithTimeInterval(interval: NSTimeInterval, repeats: Bool = false,
+    class public func scheduledTimerWithTimeInterval(interval: NSTimeInterval, repeated: Bool = false,
         handler: CKTimerHandler) -> NSTimer
     {
         return NSTimer.scheduledTimerWithTimeInterval(interval, target: self,
             selector: #selector(NSTimer.invokeFromTimer(_:)),
-            userInfo: TimerClosureWrapper(handler: handler, repeats: repeats), repeats: repeats)
+            userInfo: TimerClosureWrapper(handler: handler, repeats: repeated), repeats: repeated)
     }
 
     // MARK: Private methods


### PR DESCRIPTION
`scheduledTimerWithTimeInterval(:repeats:handler:)` is sherlocked by
iOS 10/macOS 11.12/watchOS 3/tvOS 10 SDK. In detail, Apple added a class method
on NSTimer that has the same signature except the label for the last parameter:

```
scheduledTimerWithTimeInterval(repeats:block:)
```

Call sites that uses trailing closure syntax will not compile in Xcode 10 due
to the ambiguity here.

For projects that need to support OS versions older than the ones listed above,
they need a way to keep using the ClosureKit version. Renaming the label on
the second argument is a solution (suggested by @keith and @mallorypaine).
