### PR TITLE
Update for watchOS and further rename to LamdaKit

### DIFF
--- a/Source/AVAudioPlayer+LambdaKit.swift
+++ b/Source/AVAudioPlayer+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  AVAudioPlayer+ClosureKit.swift
+//  AVAudioPlayer+LambdaKit.swift
 //  Created by Matias Pequeno on 9/23/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -25,8 +25,8 @@
 import Foundation
 import AVFoundation
 
-public typealias CKDidFinishPlayingClosure = (AVAudioPlayer, Bool) -> Void
-public typealias CKDecodeErrorDidOccurClosure = (AVAudioPlayer, NSError?) -> Void
+public typealias LKDidFinishPlayingClosure = (AVAudioPlayer, Bool) -> Void
+public typealias LKDecodeErrorDidOccurClosure = (AVAudioPlayer, NSError?) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -65,13 +65,13 @@ extension AVAudioPlayer: AVAudioPlayerDelegate {
 
     /// The closure that fires when a sound has finished playing. This method is NOT called if the player is
     /// stopped due to an interruption.
-    public var didFinishPlaying: CKDidFinishPlayingClosure? {
+    public var didFinishPlaying: LKDidFinishPlayingClosure? {
         set { self.closuresWrapper.didFinishPlaying = newValue }
         get { return self.closuresWrapper.didFinishPlaying }
     }
 
     /// The closure that fires if an error occurs while decoding it will be reported to the delegate.
-    public var decodeErrorDidOccur: CKDecodeErrorDidOccurClosure? {
+    public var decodeErrorDidOccur: LKDecodeErrorDidOccurClosure? {
         set { self.closuresWrapper.decodeErrorDidOccur = newValue }
         get { return self.closuresWrapper.decodeErrorDidOccur }
     }
@@ -84,7 +84,7 @@ extension AVAudioPlayer: AVAudioPlayerDelegate {
 
     - returns: Returns `true` on success, or `false` on failure.
     */
-    public func play(didFinishPlaying closure: CKDidFinishPlayingClosure) -> Bool {
+    public func play(didFinishPlaying closure: LKDidFinishPlayingClosure) -> Bool {
         self.didFinishPlaying = closure
         return self.play()
     }
@@ -101,6 +101,6 @@ extension AVAudioPlayer: AVAudioPlayerDelegate {
 }
 
 private final class ClosuresWrapper {
-    private var didFinishPlaying: CKDidFinishPlayingClosure?
-    private var decodeErrorDidOccur: CKDecodeErrorDidOccurClosure?
+    private var didFinishPlaying: LKDidFinishPlayingClosure?
+    private var decodeErrorDidOccur: LKDecodeErrorDidOccurClosure?
 }

--- a/Source/AVSpeechSynthesizer+LambdaKit.swift
+++ b/Source/AVSpeechSynthesizer+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  AVSpeechSynthesizer+ClosureKit.swift
+//  AVSpeechSynthesizer+LambdaKit.swift
 //  Created by Matias Pequeno on 9/23/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -25,12 +25,12 @@
 import Foundation
 import AVFoundation
 
-public typealias CKDidStartSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
-public typealias CKDidFinishSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
-public typealias CKDidPauseSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
-public typealias CKDidContinueSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
-public typealias CKDidCancelSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
-public typealias CKWillSpeakRangeOfSpeechString = (AVSpeechSynthesizer, NSRange, AVSpeechUtterance) -> Void
+public typealias LKDidStartSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
+public typealias LKDidFinishSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
+public typealias LKDidPauseSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
+public typealias LKDidContinueSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
+public typealias LKDidCancelSpeechUtterance = (AVSpeechSynthesizer, AVSpeechUtterance) -> Void
+public typealias LKWillSpeakRangeOfSpeechString = (AVSpeechSynthesizer, NSRange, AVSpeechUtterance) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -68,37 +68,37 @@ extension AVSpeechSynthesizer: AVSpeechSynthesizerDelegate {
     }
 
     /// The closure that fires when the synthesizer has begun speaking an utterance.
-    public var didStartSpeechUtterance: CKDidStartSpeechUtterance? {
+    public var didStartSpeechUtterance: LKDidStartSpeechUtterance? {
         set { self.closuresWrapper.didStartSpeechUtterance = newValue }
         get { return self.closuresWrapper.didStartSpeechUtterance }
     }
 
     /// The closure that fires when the synthesizer has finished speaking an utterance.
-    public var didFinishSpeechUtterance: CKDidFinishSpeechUtterance? {
+    public var didFinishSpeechUtterance: LKDidFinishSpeechUtterance? {
         set { self.closuresWrapper.didFinishSpeechUtterance = newValue }
         get { return self.closuresWrapper.didFinishSpeechUtterance }
     }
 
     /// The closure that fires when the synthesizer has paused while speaking an utterance.
-    public var didPauseUtterance: CKDidPauseSpeechUtterance? {
+    public var didPauseUtterance: LKDidPauseSpeechUtterance? {
         set { self.closuresWrapper.didPauseSpeechUtterance = newValue }
         get { return self.closuresWrapper.didPauseSpeechUtterance }
     }
 
     /// The closure that fires when the synthesizer has resumed speaking an utterance after being paused.
-    public var didContinueSpeechUtterance: CKDidContinueSpeechUtterance? {
+    public var didContinueSpeechUtterance: LKDidContinueSpeechUtterance? {
         set { self.closuresWrapper.didContinueSpeechUtterance = newValue }
         get { return self.closuresWrapper.didContinueSpeechUtterance }
     }
 
     /// The closure that fires when the synthesizer has canceled speaking an utterance.
-    public var didCancelSpeechUtterance: CKDidCancelSpeechUtterance? {
+    public var didCancelSpeechUtterance: LKDidCancelSpeechUtterance? {
         set { self.closuresWrapper.didCancelSpeechUtterance = newValue }
         get { return self.closuresWrapper.didCancelSpeechUtterance }
     }
 
     /// The closure that fires when the synthesizer is about to speak a portion of an utterance’s text.
-    public var willSpeakRangeOfSpeechString: CKWillSpeakRangeOfSpeechString? {
+    public var willSpeakRangeOfSpeechString: LKWillSpeakRangeOfSpeechString? {
         set { self.closuresWrapper.willSpeakRangeOfSpeechString = newValue }
         get { return self.closuresWrapper.willSpeakRangeOfSpeechString }
     }
@@ -111,7 +111,7 @@ extension AVSpeechSynthesizer: AVSpeechSynthesizerDelegate {
                            synthesizer is paused or canceled.
     */
     public func speakUtterance(utterance: AVSpeechUtterance,
-        didFinishUtterance closure: CKDidFinishSpeechUtterance)
+        didFinishUtterance closure: LKDidFinishSpeechUtterance)
     {
         self.didFinishSpeechUtterance = closure
         self.speakUtterance(utterance)
@@ -157,10 +157,10 @@ extension AVSpeechSynthesizer: AVSpeechSynthesizerDelegate {
 }
 
 private final class ClosuresWrapper {
-    private var didStartSpeechUtterance: CKDidStartSpeechUtterance?
-    private var didFinishSpeechUtterance: CKDidFinishSpeechUtterance?
-    private var didPauseSpeechUtterance: CKDidPauseSpeechUtterance?
-    private var didContinueSpeechUtterance: CKDidContinueSpeechUtterance?
-    private var didCancelSpeechUtterance: CKDidCancelSpeechUtterance?
-    private var willSpeakRangeOfSpeechString: CKWillSpeakRangeOfSpeechString?
+    private var didStartSpeechUtterance: LKDidStartSpeechUtterance?
+    private var didFinishSpeechUtterance: LKDidFinishSpeechUtterance?
+    private var didPauseSpeechUtterance: LKDidPauseSpeechUtterance?
+    private var didContinueSpeechUtterance: LKDidContinueSpeechUtterance?
+    private var didCancelSpeechUtterance: LKDidCancelSpeechUtterance?
+    private var willSpeakRangeOfSpeechString: LKWillSpeakRangeOfSpeechString?
 }

--- a/Source/CADisplayLink+LambdaKit.swift
+++ b/Source/CADisplayLink+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  CADisplayLink+ClosureKit.swift
+//  CADisplayLink+LambdaKit.swift
 //  Created by Martin Conte Mac Donell on 4/7/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -25,7 +25,7 @@
 import Foundation
 import QuartzCore
 
-public typealias CKDisplayLinkClosure = (progress: Double) -> Void
+public typealias LKDisplayLinkClosure = (progress: Double) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -60,7 +60,7 @@ extension CADisplayLink {
     :param: duration The duration in seconds.
     :param: handler  The closure to execute for every tick
     */
-    public class func runFor(duration: CFTimeInterval, handler: CKDisplayLinkClosure) {
+    public class func runFor(duration: CFTimeInterval, handler: LKDisplayLinkClosure) {
         let displayLink = CADisplayLink(target: self, selector: #selector(CADisplayLink.tick(_:)))
 
         displayLink.closureWrapper = ClosuresWrapper(handler: handler, duration: duration)
@@ -89,11 +89,11 @@ extension CADisplayLink {
 // MARK: - Private classes
 
 private final class ClosuresWrapper {
-    private var handler: CKDisplayLinkClosure
+    private var handler: LKDisplayLinkClosure
     private var duration: CFTimeInterval
     private var startTime: CFTimeInterval = 0.0
 
-    init(handler: CKDisplayLinkClosure, duration: CFTimeInterval) {
+    init(handler: LKDisplayLinkClosure, duration: CFTimeInterval) {
         self.handler = handler
         self.duration = duration
     }

--- a/Source/CLLocationManager+LambdaKit.swift
+++ b/Source/CLLocationManager+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  CLLocationManager+ClosureKit.swift
+//  CLLocationManager+LambdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -24,7 +24,7 @@
 
 import CoreLocation
 
-public typealias CKCoreLocationHandler = CLLocation -> Void
+public typealias LKCoreLocationHandler = CLLocation -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -65,9 +65,9 @@ extension CLLocationManager: CLLocationManagerDelegate {
     /**
     Starts monitoring GPS location changes and call the given closure for each change.
 
-    :param: completion A closure that will be called passing as the first argument the device's location.
+    - parameter completion: A closure that will be called passing as the first argument the device's location.
     */
-    public func startUpdatingLocation(completion: CKCoreLocationHandler) {
+    public func startUpdatingLocation(completion: LKCoreLocationHandler) {
         self.closureWrapper = ClosureWrapper(handler: completion)
         self.delegate = self
         self.startUpdatingLocation()
@@ -86,11 +86,27 @@ extension CLLocationManager: CLLocationManagerDelegate {
     }
 
     /**
+    Request the current location which is reported in the completion handler
+
+    - parameter completion: A closure that will be called with the device's current location.
+    */
+    @available(iOS 9, watchOS 2, *)
+    public func requestLocation(completion: LKCoreLocationHandler) {
+        self.closureWrapper = ClosureWrapper(handler: completion)
+        self.delegate = self
+        self.requestLocation()
+        if let location = self.location {
+            completion(location)
+        }
+    }
+
+#if !os(watchOS)
+    /**
     Starts monitoring significant location changes and call the given closure for each change.
 
     :param: completion A closure that will be called passing as the first argument the device's location.
     */
-    public func startMonitoringSignificantLocationChanges(completion: CKCoreLocationHandler) {
+    public func startMonitoringSignificantLocationChanges(completion: LKCoreLocationHandler) {
         self.closureWrapper = ClosureWrapper(handler: completion)
         self.delegate = self
         self.startMonitoringSignificantLocationChanges()
@@ -104,6 +120,7 @@ extension CLLocationManager: CLLocationManagerDelegate {
         self.closureWrapper = nil
         self.delegate = nil
     }
+#endif
 
     public func locationManager(manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let handler = self.closureWrapper?.handler, let location = manager.location {
@@ -115,9 +132,9 @@ extension CLLocationManager: CLLocationManagerDelegate {
 // MARK: - Private Classes
 
 private final class ClosureWrapper {
-    private var handler: CKCoreLocationHandler
+    private var handler: LKCoreLocationHandler
 
-    init(handler: CKCoreLocationHandler) {
+    init(handler: LKCoreLocationHandler) {
         self.handler = handler
     }
 }

--- a/Source/MFMailComposeViewController+LambdaKit.swift
+++ b/Source/MFMailComposeViewController+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  MFMailComposeViewController+ClosureKit.swift
+//  MFMailComposeViewController+LamdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -24,7 +24,7 @@
 
 import MessageUI
 
-public typealias CKMailComposerHandler = (MFMailComposeViewController, MFMailComposeResult, NSError?) -> Void
+public typealias LKMailComposerHandler = (MFMailComposeViewController, MFMailComposeResult, NSError?) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -68,7 +68,7 @@ extension MFMailComposeViewController: MFMailComposeViewControllerDelegate {
 
     :returns: an initialized instance of MFMailComposeViewController.
     */
-    public convenience init(completion: CKMailComposerHandler) {
+    public convenience init(completion: LKMailComposerHandler) {
         self.init()
 
         self.closureWrapper = ClosureWrapper(handler: completion)
@@ -91,9 +91,9 @@ extension MFMailComposeViewController: MFMailComposeViewControllerDelegate {
 // MARK: - Private Classes
 
 private final class ClosureWrapper {
-    private var handler: CKMailComposerHandler
+    private var handler: LKMailComposerHandler
 
-    init(handler: CKMailComposerHandler) {
+    init(handler: LKMailComposerHandler) {
         self.handler = handler
     }
 }

--- a/Source/MFMessageComposeViewController+LambdaKit.swift
+++ b/Source/MFMessageComposeViewController+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  MFMessageComposeViewController+ClosureKit.swift
+//  MFMessageComposeViewController+LambdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -24,7 +24,7 @@
 
 import MessageUI
 
-public typealias CKMessageComposerHandler = (MFMessageComposeViewController, MessageComposeResult) -> Void
+public typealias LKMessageComposerHandler = (MFMessageComposeViewController, MessageComposeResult) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -68,7 +68,7 @@ extension MFMessageComposeViewController: MFMessageComposeViewControllerDelegate
 
     :returns: an initialized instance of MFMessageComposeViewController.
     */
-    public convenience init(completion: CKMessageComposerHandler) {
+    public convenience init(completion: LKMessageComposerHandler) {
         self.init()
 
         self.closureWrapper = ClosureWrapper(handler: completion)
@@ -77,7 +77,7 @@ extension MFMessageComposeViewController: MFMessageComposeViewControllerDelegate
 
     // MARK: MFMessageComposeViewControllerDelegate implementation
 
-    public func messageComposeViewController(controller: MFMessageComposeViewController,
+    private func messageComposeViewController(controller: MFMessageComposeViewController,
         didFinishWithResult result: MessageComposeResult)
     {
         controller.dismissViewControllerAnimated(true, completion: nil)
@@ -90,9 +90,9 @@ extension MFMessageComposeViewController: MFMessageComposeViewControllerDelegate
 // MARK: - Private classes
 
 private final class ClosureWrapper {
-    private var handler: CKMessageComposerHandler
+    private var handler: LKMessageComposerHandler
 
-    init(handler: CKMessageComposerHandler) {
+    init(handler: LKMessageComposerHandler) {
         self.handler = handler
     }
 }

--- a/Source/NSObject+LambdaKit.swift
+++ b/Source/NSObject+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  NSObject+ClosureKit.swift
+//  NSObject+LambdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -24,7 +24,7 @@
 
 import Foundation
 
-public typealias CKObserverHandler = (newValue: AnyObject?, oldValue: AnyObject?) -> Void
+public typealias LKObserverHandler = (newValue: AnyObject?, oldValue: AnyObject?) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -79,7 +79,7 @@ extension NSObject {
     :returns: a globally unique identifier for removing observation with removeObserver(token:).
     */
     public func observeKeyPath(keyPath: String, options: NSKeyValueObservingOptions = .New,
-        token: String? = nil, handler: CKObserverHandler) -> String
+        token: String? = nil, handler: LKObserverHandler) -> String
     {
         if self.observer == nil {
             self.observer = NSObjectObserver()
@@ -128,13 +128,13 @@ extension NSObject {
 
 private final class NSObjectObserver: NSObject {
 
-    private var handlers: [String: [(token: String, handler: CKObserverHandler)]] = [:]
+    private var handlers: [String: [(token: String, handler: LKObserverHandler)]] = [:]
 
     private func hasObservers(forKeyPath keyPath: String) -> Bool {
         return handlers[keyPath]?.count > 0
     }
 
-    private func addHandler(handler: CKObserverHandler, forKeyPath keyPath: String, token: String) {
+    private func addHandler(handler: LKObserverHandler, forKeyPath keyPath: String, token: String) {
         if self.handlers[keyPath] == nil {
             self.handlers[keyPath] = []
         }

--- a/Source/NSTimer+LambdaKit.swift
+++ b/Source/NSTimer+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  UIGestureRecognizer+ClosureKit.swift
+//  NSTimer+LambdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -24,7 +24,7 @@
 
 import Foundation
 
-public typealias CKTimerHandler = (timer: NSTimer) -> Void
+public typealias LKTimerHandler = (timer: NSTimer) -> Void
 
 /**
 Simple closure implementation on NSTimer scheduling.
@@ -50,7 +50,7 @@ extension NSTimer {
     :returns: a new NSTimer object, configured according to the specified parameters.
     */
     class public func scheduledTimerWithTimeInterval(interval: NSTimeInterval, repeated: Bool = false,
-        handler: CKTimerHandler) -> NSTimer
+        handler: LKTimerHandler) -> NSTimer
     {
         return NSTimer.scheduledTimerWithTimeInterval(interval, target: self,
             selector: #selector(NSTimer.invokeFromTimer(_:)),
@@ -70,10 +70,10 @@ extension NSTimer {
 // MARK: - Private classes
 
 private final class TimerClosureWrapper {
-    private var handler: CKTimerHandler
+    private var handler: LKTimerHandler
     private var repeats: Bool
 
-    init(handler: CKTimerHandler, repeats: Bool) {
+    init(handler: LKTimerHandler, repeats: Bool) {
         self.handler = handler
         self.repeats = repeats
     }

--- a/Source/UIBarButtonItem+LambdaKit.swift
+++ b/Source/UIBarButtonItem+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  UIGestureRecognizer+ClosureKit.swift
+//  UIBarButtonItem+LamdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -22,31 +22,30 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+import Foundation
 import UIKit
 
-public typealias CKGestureHandler = (sender: UIGestureRecognizer, state: UIGestureRecognizerState) -> Void
+public typealias LKBarButtonHandler = (sender: UIBarButtonItem) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-Closure functionality for UIGestureRecognizer.
+/** 
+Closure event initialization for UIBarButtonItem.
 
-Example: 
+Example:
 
 ```swift
-let doubleTap = UITapGestureRecognizer { gesture, state in
-    println("Double tap!")
+self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: image, style: .Bordered) { btn in
+    println("Button touched!!!!!! \(btn)")
 }
-doubleTap.numberOfTapsRequired = 2
-self.addGestureRecognizer(doubleTap)
 ```
 */
-extension UIGestureRecognizer {
+extension UIBarButtonItem {
 
-    private var closureWrapper: GestureClosureWrapper? {
+    private var closuresWrapper: ClosureWrapper? {
         get {
-            return objc_getAssociatedObject(self, &associatedEventHandle) as? GestureClosureWrapper
+            return objc_getAssociatedObject(self, &associatedEventHandle) as? ClosureWrapper
         }
 
         set {
@@ -56,34 +55,34 @@ extension UIGestureRecognizer {
     }
 
     /**
-    Initializes an allocated gesture recognizer that will call the given closure when the gesture is 
-    recognized.
+    Initializes an UIBarButtonItem that will call the given closure when the button is touched.
 
-    An alternative to the designated initializer.
+    :param: image   The item’s image. If nil an image is not displayed.
+    :param: style   The style of the item. One of the constants defined in UIBarButtonItemStyle.
+    :param: handler The closure which handles button touches.
 
-    :param: handler The closure which handles an executed gesture.
-
-    :returns: an initialized instance of a concrete UIGestureRecognizer subclass.
+    :returns: an initialized instance of UIBarButtonItem.
     */
-    public convenience init(handler: CKGestureHandler) {
-        self.init()
-
-        self.closureWrapper = GestureClosureWrapper(handler: handler)
-        self.addTarget(self, action: #selector(UIGestureRecognizer.handleAction))
+    public convenience init(image: UIImage?, style: UIBarButtonItemStyle, handler: LKBarButtonHandler) {
+        self.init(image: image, style: style, target: nil, action: #selector(UIBarButtonItem.handleAction))
+        self.closuresWrapper = ClosureWrapper(handler: handler)
+        self.target = self
     }
+
+    // MARK: Private methods
 
     @objc
     private func handleAction() {
-        self.closureWrapper?.handler(sender: self, state: self.state)
+        self.closuresWrapper?.handler(sender: self)
     }
 }
 
 // MARK: - Private classes
 
-private final class GestureClosureWrapper {
-    private var handler: CKGestureHandler
+private final class ClosureWrapper {
+    private var handler: LKBarButtonHandler
 
-    init(handler: CKGestureHandler) {
+    init(handler: LKBarButtonHandler) {
         self.handler = handler
     }
 }

--- a/Source/UIControl+LambdaKit.swift
+++ b/Source/UIControl+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  UIControl+ClosureKit.swift
+//  UIControl+LamdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -24,16 +24,16 @@
 
 import UIKit
 
-public typealias CKControlHandler = (sender: UIControl) -> Void
+public typealias LKControlHandler = (sender: UIControl) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
 private final class ControlWrapper {
     private var controlEvents: UIControlEvents
-    private var handler: CKControlHandler
+    private var handler: LKControlHandler
 
-    init(handler: CKControlHandler, events: UIControlEvents) {
+    init(handler: LKControlHandler, events: UIControlEvents) {
         self.handler = handler
         self.controlEvents = events
     }
@@ -75,7 +75,7 @@ extension UIControl {
     :param: controlEvents A bitmask specifying the control events for which the action message is sent.
     :param: handler A block representing an action message, with an argument for the sender.
     */
-    public func addEventHandler(forControlEvents controlEvents: UIControlEvents, handler: CKControlHandler) {
+    public func addEventHandler(forControlEvents controlEvents: UIControlEvents, handler: LKControlHandler) {
         let target = ControlWrapper(handler: handler, events: controlEvents)
         self.addTarget(target, action: #selector(ControlWrapper.invoke(_:)), forControlEvents: controlEvents)
 

--- a/Source/UIGestureRecognizer+LambdaKit.swift
+++ b/Source/UIGestureRecognizer+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  UIBarButtonItem+ClosureKit.swift
+//  UIGestureRecognizer+LamdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -22,30 +22,31 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import Foundation
 import UIKit
 
-public typealias CKBarButtonHandler = (sender: UIBarButtonItem) -> Void
+public typealias LKGestureHandler = (sender: UIGestureRecognizer, state: UIGestureRecognizerState) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/** 
-Closure event initialization for UIBarButtonItem.
+/**
+Closure functionality for UIGestureRecognizer.
 
-Example:
+Example: 
 
 ```swift
-self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: image, style: .Bordered) { btn in
-    println("Button touched!!!!!! \(btn)")
+let doubleTap = UITapGestureRecognizer { gesture, state in
+    println("Double tap!")
 }
+doubleTap.numberOfTapsRequired = 2
+self.addGestureRecognizer(doubleTap)
 ```
 */
-extension UIBarButtonItem {
+extension UIGestureRecognizer {
 
-    private var closuresWrapper: ClosureWrapper? {
+    private var closureWrapper: GestureClosureWrapper? {
         get {
-            return objc_getAssociatedObject(self, &associatedEventHandle) as? ClosureWrapper
+            return objc_getAssociatedObject(self, &associatedEventHandle) as? GestureClosureWrapper
         }
 
         set {
@@ -55,34 +56,34 @@ extension UIBarButtonItem {
     }
 
     /**
-    Initializes an UIBarButtonItem that will call the given closure when the button is touched.
+    Initializes an allocated gesture recognizer that will call the given closure when the gesture is 
+    recognized.
 
-    :param: image   The item’s image. If nil an image is not displayed.
-    :param: style   The style of the item. One of the constants defined in UIBarButtonItemStyle.
-    :param: handler The closure which handles button touches.
+    An alternative to the designated initializer.
 
-    :returns: an initialized instance of UIBarButtonItem.
+    :param: handler The closure which handles an executed gesture.
+
+    :returns: an initialized instance of a concrete UIGestureRecognizer subclass.
     */
-    public convenience init(image: UIImage?, style: UIBarButtonItemStyle, handler: CKBarButtonHandler) {
-        self.init(image: image, style: style, target: nil, action: #selector(UIBarButtonItem.handleAction))
-        self.closuresWrapper = ClosureWrapper(handler: handler)
-        self.target = self
-    }
+    public convenience init(handler: LKGestureHandler) {
+        self.init()
 
-    // MARK: Private methods
+        self.closureWrapper = GestureClosureWrapper(handler: handler)
+        self.addTarget(self, action: #selector(UIGestureRecognizer.handleAction))
+    }
 
     @objc
     private func handleAction() {
-        self.closuresWrapper?.handler(sender: self)
+        self.closureWrapper?.handler(sender: self, state: self.state)
     }
 }
 
 // MARK: - Private classes
 
-private final class ClosureWrapper {
-    private var handler: CKBarButtonHandler
+private final class GestureClosureWrapper {
+    private var handler: LKGestureHandler
 
-    init(handler: CKBarButtonHandler) {
+    init(handler: LKGestureHandler) {
         self.handler = handler
     }
 }

--- a/Source/UIImagePickerController+LambdaKit.swift
+++ b/Source/UIImagePickerController+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  UIImagePickerController+ClosureKit.swift
+//  UIImagePickerController+LamdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -25,8 +25,8 @@
 import Foundation
 import UIKit
 
-public typealias CKFinishPickingMediaClosure = (UIImagePickerController, [NSObject: AnyObject]) -> Void
-public typealias CKCancelClosure = (UIImagePickerController) -> Void
+public typealias LKFinishPickingMediaClosure = (UIImagePickerController, [NSObject: AnyObject]) -> Void
+public typealias LKCancelClosure = (UIImagePickerController) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -68,13 +68,13 @@ extension UIImagePickerController: UIImagePickerControllerDelegate, UINavigation
     }
 
     /// The closure that fires after the receiver finished picking up an image.
-    public var didFinishPickingMedia: CKFinishPickingMediaClosure? {
+    public var didFinishPickingMedia: LKFinishPickingMediaClosure? {
         set { self.closuresWrapper.didFinishPickingMedia = newValue }
         get { return self.closuresWrapper.didFinishPickingMedia }
     }
 
     /// The closure that fires after the user cancels out of picker.
-    public var didCancel: CKCancelClosure? {
+    public var didCancel: LKCancelClosure? {
         set { self.closuresWrapper.didCancel = newValue }
         get { return self.closuresWrapper.didCancel }
     }
@@ -95,6 +95,6 @@ extension UIImagePickerController: UIImagePickerControllerDelegate, UINavigation
 // MARK: - Private classes
 
 private final class ClosuresWrapper {
-    private var didFinishPickingMedia: CKFinishPickingMediaClosure?
-    private var didCancel: CKCancelClosure?
+    private var didFinishPickingMedia: LKFinishPickingMediaClosure?
+    private var didCancel: LKCancelClosure?
 }

--- a/Source/UIWebView+LambdaKit.swift
+++ b/Source/UIWebView+LambdaKit.swift
@@ -1,5 +1,5 @@
 //
-//  UIWebView+ClosureKit.swift
+//  UIWebView+LamdaKit.swift
 //  Created by Martin Conte Mac Donell on 3/31/15.
 //
 //  Copyright (c) 2015 Lyft (http://lyft.com)
@@ -25,10 +25,10 @@
 import Foundation
 import UIKit
 
-public typealias CKShouldStartClosure = (UIWebView, NSURLRequest, UIWebViewNavigationType) -> Bool
-public typealias CKDidStartClosure = (UIWebView) -> Void
-public typealias CKDidFinishLoadClosure = (UIWebView) -> Void
-public typealias CKDidFinishWithErrorClosure = (UIWebView, NSError?) -> Void
+public typealias LKShouldStartClosure = (UIWebView, NSURLRequest, UIWebViewNavigationType) -> Bool
+public typealias LKDidStartClosure = (UIWebView) -> Void
+public typealias LKDidFinishLoadClosure = (UIWebView) -> Void
+public typealias LKDidFinishWithErrorClosure = (UIWebView, NSError?) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -82,25 +82,25 @@ extension UIWebView: UIWebViewDelegate {
     }
 
     /// The closure to be decide whether a URL will be loaded.
-    public var shouldStartLoad: CKShouldStartClosure? {
+    public var shouldStartLoad: LKShouldStartClosure? {
         set { self.closuresWrapper.shouldStartLoad = newValue }
         get { return self.closuresWrapper.shouldStartLoad }
     }
 
     /// The closure that is fired when the web view starts loading.
-    public var didStartLoad: CKDidStartClosure? {
+    public var didStartLoad: LKDidStartClosure? {
         set { self.closuresWrapper.didStartLoad = newValue }
         get { return self.closuresWrapper.didStartLoad }
     }
 
     /// The closure that is fired when the web view finishes loading.
-    public var didFinishLoad: CKDidFinishLoadClosure? {
+    public var didFinishLoad: LKDidFinishLoadClosure? {
         set { self.closuresWrapper.didFinishLoad = newValue }
         get { return self.closuresWrapper.didFinishLoad }
     }
 
     /// The closure that is fired when the web view stops loading due to an error.
-    public var didFinishWithError: CKDidFinishWithErrorClosure? {
+    public var didFinishWithError: LKDidFinishWithErrorClosure? {
         set { self.closuresWrapper.didFinishWithError = newValue }
         get { return self.closuresWrapper.didFinishWithError }
     }
@@ -129,8 +129,8 @@ extension UIWebView: UIWebViewDelegate {
 // MARK: - Private classes
 
 private final class ClosuresWrapper {
-    private var shouldStartLoad: CKShouldStartClosure?
-    private var didStartLoad: CKDidStartClosure?
-    private var didFinishLoad: CKDidFinishLoadClosure?
-    private var didFinishWithError: CKDidFinishWithErrorClosure?
+    private var shouldStartLoad: LKShouldStartClosure?
+    private var didStartLoad: LKDidStartClosure?
+    private var didFinishLoad: LKDidFinishLoadClosure?
+    private var didFinishWithError: LKDidFinishWithErrorClosure?
 }


### PR DESCRIPTION
- Adds `#if os(watchOS)` checks for methods that are only available on watchOS
- Renames files and handlers to `+LamdaKit` an `LK`
- ~~Deletes `CADisplayLink+ClosureKit` since we weren't using that anymore (may be an undesired change)~~
