### PR TITLE
Update for iOS 10/watchOS 3

### DIFF
--- a/LambdaKit.podspec
+++ b/LambdaKit.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
 
   s.ios.source_files = 'Source/*.swift'
-  s.watchos.source_files = 'Source/NSObject*.swift', 'Source/NSTimer*.swift'
+  s.watchos.source_files = 'Source/NSObject*.swift', 'Source/NSTimer*.swift', 'Source/CLLocationManager*.swift'
 end

--- a/Source/AVAudioPlayer+LambdaKit.swift
+++ b/Source/AVAudioPlayer+LambdaKit.swift
@@ -31,18 +31,16 @@ public typealias LKDecodeErrorDidOccurClosure = (AVAudioPlayer, NSError?) -> Voi
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-AVAudioPlayer with closure callback(s).
-
-Example:
-
-```swift
-let player = try? AVAudioPlayer(contentsOfURL: soundURL)
-player?.play { player, success in
-    // deactivate audio session
-}
-```
-*/
+/// AVAudioPlayer with closure callback(s).
+///
+/// Example:
+///
+/// ```swift
+/// let player = try? AVAudioPlayer(contentsOfURL: soundURL)
+/// player?.play { player, success in
+///     // deactivate audio session
+/// }
+/// ```
 extension AVAudioPlayer: AVAudioPlayerDelegate {
 
     private var closuresWrapper: ClosuresWrapper {
@@ -76,14 +74,12 @@ extension AVAudioPlayer: AVAudioPlayerDelegate {
         get { return self.closuresWrapper.decodeErrorDidOccur }
     }
 
-    /**
-    Plays a sound asynchronously.
-
-    - parameter didFinishPlaying: Closure to be invoked when audio finishes playing. This won't be invoked if
-                                  the player stopped due to an interruption.
-
-    - returns: Returns `true` on success, or `false` on failure.
-    */
+    /// Plays a sound asynchronously.
+    ///
+    /// - parameter didFinishPlaying: Closure to be invoked when audio finishes playing. This won't be invoked
+    ///                               if the player stopped due to an interruption.
+    ///
+    /// - returns: Returns `true` on success, or `false` on failure.
     public func play(didFinishPlaying closure: LKDidFinishPlayingClosure) -> Bool {
         self.didFinishPlaying = closure
         return self.play()

--- a/Source/AVSpeechSynthesizer+LambdaKit.swift
+++ b/Source/AVSpeechSynthesizer+LambdaKit.swift
@@ -35,18 +35,16 @@ public typealias LKWillSpeakRangeOfSpeechString = (AVSpeechSynthesizer, NSRange,
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-AVSpeechSynthesizer with closure callback(s).
-
-Example:
-
-```swift
-let player = try? AVAudioPlayer(contentsOfURL: soundURL)
-player?.play { player, success in
-// deactivate audio session
-}
-```
-*/
+/// AVSpeechSynthesizer with closure callback(s).
+///
+/// Example:
+///
+/// ```swift
+/// let player = try?  AVAudioPlayer(contentsOfURL: soundURL)
+/// player?.play { player, success in
+///     // deactivate audio session
+/// }
+/// ```
 extension AVSpeechSynthesizer: AVSpeechSynthesizerDelegate {
 
     private var closuresWrapper: ClosuresWrapper {
@@ -103,13 +101,11 @@ extension AVSpeechSynthesizer: AVSpeechSynthesizerDelegate {
         get { return self.closuresWrapper.willSpeakRangeOfSpeechString }
     }
 
-    /**
-    Enqueues an utterance to be spoken.
-
-    - parameter utterance: An AVSpeechUtterance object containing text to be spoken.
-    - parameter closure:   Closure to be called when speech finishes speaking. This won't be called if the
-                           synthesizer is paused or canceled.
-    */
+    /// Enqueues an utterance to be spoken.
+    ///
+    /// - parameter utterance: An AVSpeechUtterance object containing text to be spoken.
+    /// - parameter closure:   Closure to be called when speech finishes speaking. This won't be called if the
+    ///                        synthesizer is paused or canceled.
     public func speakUtterance(utterance: AVSpeechUtterance,
         didFinishUtterance closure: LKDidFinishSpeechUtterance)
     {

--- a/Source/CADisplayLink+LambdaKit.swift
+++ b/Source/CADisplayLink+LambdaKit.swift
@@ -30,16 +30,15 @@ public typealias LKDisplayLinkClosure = (progress: Double) -> Void
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-CADisplayLink closures implementation.
-
-Example:
-```swift
-CADisplayLink.runFor(5.0) { progress in
-    println("Awesome \(progress * 100)%")
-}
-```
-*/
+/// CADisplayLink closures implementation.
+///
+/// Example:
+///
+/// ```swift
+/// CADisplayLink.runFor(5.0) { progress in
+///     println("Awesome \(progress * 100)%")
+/// }
+/// ```
 extension CADisplayLink {
 
     private var closureWrapper: ClosuresWrapper? {
@@ -53,13 +52,11 @@ extension CADisplayLink {
         }
     }
 
-    /**
-    Creates a DisplayLink and add it to the main run loop. The displayLink will execute for the given 
-    duration in seconds.
-
-    - parameter duration: The duration in seconds.
-    - parameter handler:  The closure to execute for every tick.
-    */
+    /// Creates a DisplayLink and add it to the main run loop. The displayLink will execute for the given
+    /// duration in seconds.
+    ///
+    /// - parameter duration: The duration in seconds.
+    /// - parameter handler:  The closure to execute for every tick.
     public class func runFor(duration: CFTimeInterval, handler: LKDisplayLinkClosure) {
         let displayLink = CADisplayLink(target: self, selector: #selector(CADisplayLink.tick(_:)))
 

--- a/Source/CLLocationManager+LambdaKit.swift
+++ b/Source/CLLocationManager+LambdaKit.swift
@@ -29,32 +29,28 @@ public typealias LKCoreLocationHandler = LKLocationOrError -> Void
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-CLLocationManager with closure callback.
+/// CLLocationManager with closure callback.
+///
+/// Note that when using startUpdatingLocation(handler) you need to use the counterpart 
+/// `stopUpdatingLocationHandler` or you'll leak memory.
+///
+/// Example:
+///
+/// ```swift let
+///     locationManager = CLLocationManager()
+///     locationManager.starUpdatingLocation { location in
+///         print("Location: \(location)")
+///     }
+///     locationManager.stopUpdatingLocationHandler()
+/// ```
+///
+/// WARNING: You cannot use closures *and* set a delegate at the same time. Setting a delegate will prevent
+/// closures for being called and setting a closure will overwrite the delegate property.
 
-Note that when using startUpdatingLocation(handler) you need to use the counterpart
-`stopUpdatingLocationHandler` or you'll leak memory.
-
-Example:
-
-```swift
-let locationManager = CLLocationManager()
-locationManager.starUpdatingLocation { location in
-    println("Location: \(location)")
-}
-locationManager.stopUpdatingLocationHandler()
-```
-
-WARNING: You cannot use closures *and* set a delegate at the same time. Setting a delegate will prevent
-closures for being called and setting a closure will overwrite the delegate property.
-*/
-
-/**
- An enum that will represent either a location or an error with corresponding associated values.
-
- - Location A location as reported by Core Location.
- - Error    An error coming from Core Location, for example when location service usage is denied.
- */
+/// An enum that will represent either a location or an error with corresponding associated values. 
+///
+/// - Location: A location as reported by Core Location.
+/// - Error:    An error coming from Core Location, for example when location service usage is denied.
 public enum LKLocationOrError {
     case Location(CLLocation)
     case Error(NSError)
@@ -73,11 +69,10 @@ extension CLLocationManager: CLLocationManagerDelegate {
         }
     }
 
-    /**
-    Starts monitoring GPS location changes and call the given closure for each change.
-
-    - parameter completion: A closure that will be called passing as the first argument the device's location.
-    */
+    /// Starts monitoring GPS location changes and call the given closure for each change.
+    ///
+    /// - parameter completion: A closure that will be called passing as the first argument the device's
+    ///                         location.
     public func startUpdatingLocation(completion: LKCoreLocationHandler) {
         self.closureWrapper = ClosureWrapper(handler: completion)
         self.delegate = self
@@ -87,20 +82,16 @@ extension CLLocationManager: CLLocationManagerDelegate {
         }
     }
 
-    /**
-    Stops monitoring GPS location changes and cleanup.
-    */
+    /// Stops monitoring GPS location changes and cleanup.
     public func stopUpdatingLocationHandler() {
         self.stopUpdatingLocation()
         self.closureWrapper = nil
         self.delegate = nil
     }
 
-    /**
-    Request the current location which is reported in the completion handler
-
-    - parameter completion: A closure that will be called with the device's current location.
-    */
+    /// Request the current location which is reported in the completion handler.
+    ///
+    /// - parameter completion: A closure that will be called with the device's current location.
     @available(iOS 9, watchOS 2, *)
     public func requestLocation(completion: LKCoreLocationHandler) {
         self.closureWrapper = ClosureWrapper(handler: completion)
@@ -112,20 +103,17 @@ extension CLLocationManager: CLLocationManagerDelegate {
     }
 
 #if !os(watchOS)
-    /**
-    Starts monitoring significant location changes and call the given closure for each change.
-
-    - parameter completion: A closure that will be called passing as the first argument the device's location.
-    */
+    /// Starts monitoring significant location changes and call the given closure for each change.
+    ///
+    /// - parameter completion: A closure that will be called passing as the first argument the device's
+    ///                         location.
     public func startMonitoringSignificantLocationChanges(completion: LKCoreLocationHandler) {
         self.closureWrapper = ClosureWrapper(handler: completion)
         self.delegate = self
         self.startMonitoringSignificantLocationChanges()
     }
 
-    /**
-    Stops monitoring GPS location changes and cleanup.
-    */
+    /// Stops monitoring GPS location changes and cleanup.
     public func stopMonitoringSignificantLocationChangesHandler() {
         self.stopMonitoringSignificantLocationChanges()
         self.closureWrapper = nil

--- a/Source/CLLocationManager+LambdaKit.swift
+++ b/Source/CLLocationManager+LambdaKit.swift
@@ -24,7 +24,7 @@
 
 import CoreLocation
 
-public typealias LKCoreLocationHandler = CLLocation -> Void
+public typealias LKCoreLocationHandler = LKLocationOrError -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -49,6 +49,17 @@ WARNING: You cannot use closures *and* set a delegate at the same time. Setting 
 closures for being called and setting a closure will overwrite the delegate property.
 */
 
+/**
+ An enum that will represent either a location or an error with corresponding associated values.
+
+ - Location A location as reported by Core Location.
+ - Error    An error coming from Core Location, for example when location service usage is denied.
+ */
+public enum LKLocationOrError {
+    case Location(CLLocation)
+    case Error(NSError)
+}
+
 extension CLLocationManager: CLLocationManagerDelegate {
 
     private var closureWrapper: ClosureWrapper? {
@@ -72,7 +83,7 @@ extension CLLocationManager: CLLocationManagerDelegate {
         self.delegate = self
         self.startUpdatingLocation()
         if let location = self.location {
-            completion(location)
+            completion(.Location(location))
         }
     }
 
@@ -96,7 +107,7 @@ extension CLLocationManager: CLLocationManagerDelegate {
         self.delegate = self
         self.requestLocation()
         if let location = self.location {
-            completion(location)
+            completion(.Location(location))
         }
     }
 
@@ -124,8 +135,12 @@ extension CLLocationManager: CLLocationManagerDelegate {
 
     public func locationManager(manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let handler = self.closureWrapper?.handler, let location = manager.location {
-            handler(location)
+            handler(.Location(location))
         }
+    }
+
+    public func locationManager(manager: CLLocationManager, didFailWithError error: NSError) {
+        self.closureWrapper?.handler(.Error(error))
     }
 }
 

--- a/Source/MFMailComposeViewController+LambdaKit.swift
+++ b/Source/MFMailComposeViewController+LambdaKit.swift
@@ -29,22 +29,22 @@ public typealias LKMailComposerHandler = (MFMailComposeViewController, MFMailCom
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-MFMailComposeViewController with closure callback.
-
-Note that when setting a completion handler, you don't have the responsability to dismiss the view controller
-anymore.
-
-Example:
-
-```swift
-let composeViewController = MFMailComposeViewController { viewController, result, type in println("Done") }
-composerViewController.setSubject("Test")
-```
-
-WARNING: You cannot use closures *and* set a delegate at the same time. Setting a delegate will prevent
-closures for being called and setting a closure will overwrite the delegate property.
-*/
+/// MFMailComposeViewController with closure callback.
+///
+/// Note that when setting a completion handler, you don't have the responsability to dismiss the view 
+/// controller anymore.
+///
+/// Example:
+///
+/// ```swift let
+/// composeViewController = MFMailComposeViewController { viewController, result, type in
+///     print("Done")
+/// }
+/// composerViewController.setSubject("Test")
+/// ```
+///
+/// WARNING: You cannot use closures *and* set a delegate at the same time. Setting a delegate will prevent
+/// closures for being called and setting a closure will overwrite the delegate property.
 
 extension MFMailComposeViewController: MFMailComposeViewControllerDelegate {
 
@@ -59,15 +59,13 @@ extension MFMailComposeViewController: MFMailComposeViewControllerDelegate {
         }
     }
 
-    /** 
-    Creates an instance of MFMailComposeViewController and sets the completion closure to be used instead
-    of the delegate. This closure is an analog for the
-    mailComposeController:didFinishWithResult:error: method of MFMailComposeViewControllerDelegate.
-    
-    - parameter completion: A closure analog to mailComposeController:didFinishWithResult:error:
-
-    - returns: an initialized instance of MFMailComposeViewController.
-    */
+    /// Creates an instance of MFMailComposeViewController and sets the completion closure to be used instead of
+    /// the delegate. This closure is an analog for the mailComposeController:didFinishWithResult:error: method of
+    /// MFMailComposeViewControllerDelegate.
+    ///
+    /// - parameter completion: A closure analog to `mailComposeController:didFinishWithResult:error:`.
+    ///
+    /// - returns: An initialized instance of MFMailComposeViewController.
     public convenience init(completion: LKMailComposerHandler) {
         self.init()
 

--- a/Source/MFMessageComposeViewController+LambdaKit.swift
+++ b/Source/MFMessageComposeViewController+LambdaKit.swift
@@ -77,7 +77,7 @@ extension MFMessageComposeViewController: MFMessageComposeViewControllerDelegate
 
     // MARK: MFMessageComposeViewControllerDelegate implementation
 
-    private func messageComposeViewController(controller: MFMessageComposeViewController,
+    public func messageComposeViewController(controller: MFMessageComposeViewController,
         didFinishWithResult result: MessageComposeResult)
     {
         controller.dismissViewControllerAnimated(true, completion: nil)

--- a/Source/MFMessageComposeViewController+LambdaKit.swift
+++ b/Source/MFMessageComposeViewController+LambdaKit.swift
@@ -29,23 +29,22 @@ public typealias LKMessageComposerHandler = (MFMessageComposeViewController, Mes
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-MFMessageComposeViewController with closure callback.
-
-Note that when setting a completion handler, you don't have the responsability to dismiss the view controller
-anymore.
-
-Example:
-
-```swift
-let composeViewController = MFMessageComposeViewController { viewController, result in println("Done") }
-composerViewController.body = "test sms"
-```
-
-WARNING: You cannot use closures *and* set a delegate at the same time. Setting a delegate will prevent
-closures for being called and setting a closure will overwrite the delegate property.
-*/
-
+/// MFMessageComposeViewController with closure callback.
+///
+/// Note that when setting a completion handler, you don't have the responsability to dismiss the view
+/// controller anymore.
+///
+/// Example:
+///
+/// ```swift let
+/// composeViewController = MFMessageComposeViewController { viewController, result in
+///     print("Done")
+/// }
+/// composerViewController.body = "test sms"
+/// ```
+///
+/// WARNING: You cannot use closures *and* set a delegate at the same time. Setting a delegate will prevent
+/// closures for being called and setting a closure will overwrite the delegate property.
 extension MFMessageComposeViewController: MFMessageComposeViewControllerDelegate {
 
     private var closureWrapper: ClosureWrapper? {
@@ -59,15 +58,13 @@ extension MFMessageComposeViewController: MFMessageComposeViewControllerDelegate
         }
     }
 
-    /**
-    Creates an instance of MFMessageComposeViewController and sets the completion closure to be used instead
-    of the delegate. This closure is an analog for the messageComposeViewController:didFinishWithResult:
-    method.
-
-    - parameter completion: A closure analog to messageComposeViewController:didFinishWithResult:
-
-    - returns: an initialized instance of MFMessageComposeViewController.
-    */
+    /// Creates an instance of MFMessageComposeViewController and sets the completion closure to be used
+    /// instead of the delegate. This closure is an analog for the
+    /// messageComposeViewController:didFinishWithResult: method.
+    ///
+    /// - parameter completion: A closure analog to messageComposeViewController:didFinishWithResult:.
+    ///
+    /// - returns: An initialized instance of MFMessageComposeViewController.
     public convenience init(completion: LKMessageComposerHandler) {
         self.init()
 

--- a/Source/NSObject+LambdaKit.swift
+++ b/Source/NSObject+LambdaKit.swift
@@ -30,30 +30,28 @@ public typealias LKObserverHandler = (newValue: AnyObject?, oldValue: AnyObject?
 private var associatedEventHandle: UInt8 = 0
 private var uniqueObserverContext: UInt8 = 0
 
-/**
-Closure wrapper for key-value observation.
-
-In Mac OS X Panther, Apple introduced an API called "key-value observing."  It implements an
-[observer pattern](http://en.wikipedia.org/wiki/Observer_pattern), where an object will notify observers of
-any changes in state. NSNotification is a rudimentary form of this design style; KVO, however, allows for the
-observation of any change in key-value state. The API for key-value observation, however, is flawed, ugly,
-and lengthy.
-
-Like most of the other closure abilities in ClosureKit, observation saves and a bunch of code and a bunch
-of potential bugs.
-
-**WARNING**: Observing using closures and cocoa observers are independant. Meaning that you shouldn't
-add a "traditional" observer and then remove it using this wrapper nor add a closure observer and remove it
-using Cocoa methods.
-
-Example:
-
-```swift
-self.observeKeyPath("testing", options: .New | .Old) { newValue, oldValue in
-    println("Property was: \(oldValue), now is: \(newValue)")
-}
-```
-*/
+/// Closure wrapper for key-value observation.
+///
+/// In Mac OS X Panther, Apple introduced an API called "key-value observing."  It implements an
+/// [observer pattern](http://en.wikipedia.org/wiki/Observer_pattern), where an object will notify observers
+/// of any changes in state. NSNotification is a rudimentary form of this design style; KVO, however, allows
+/// for the observation of any change in key-value state. The API for key-value observation, however, is
+/// flawed, ugly, and lengthy.
+///
+/// Like most of the other closure abilities in LambdaKit, observation saves and a bunch of code and a bunch
+/// of potential bugs.
+///
+/// **WARNING**: Observing using closures and cocoa observers are independant. Meaning that you shouldn't add
+/// a "traditional" observer and then remove it using this wrapper nor add a closure observer and remove it
+/// using Cocoa methods.
+///
+/// Example:
+///
+/// ```swift
+/// self.observeKeyPath("testing", options: .New | .Old) { newValue, oldValue in
+///     print("Property was: \(oldValue), now is: \(newValue)")
+/// }
+/// ```
 extension NSObject {
 
     private var observer: NSObjectObserver? {
@@ -67,17 +65,16 @@ extension NSObject {
         }
     }
 
-    /**
-    Adds a closure observer that executes a block upon a state change.
-
-    :param: keyPath The property to observe, relative to the reciever.
-    :param: options The NSKeyValueObservingOptions to use.
-    :param: token   A unique identifier used to locate the closure for removal.
-    :param: handler A closure with no return argument and two parameters: the newValue and oldValue. Note that
-                    both are optionals and will be only present if included in the options parameter.
-
-    - returns: a globally unique identifier for removing observation with removeObserver(token:).
-    */
+    /// Adds a closure observer that executes a block upon a state change.
+    ///
+    /// - parameter keyPath: The property to observe, relative to the reciever.
+    /// - parameter options: The NSKeyValueObservingOptions to use.
+    /// - parameter token:   A unique identifier used to locate the closure for removal.
+    /// - parameter handler: A closure with no return argument and two parameters: the newValue and oldValue.
+    ///                      Note that both are optionals and will be only present if included in the options
+    ///                      parameter.
+    ///
+    /// - returns: A globally unique identifier for removing observation with removeObserver(token:).
     public func observeKeyPath(keyPath: String, options: NSKeyValueObservingOptions = .New,
         token: String? = nil, handler: LKObserverHandler) -> String
     {
@@ -95,11 +92,10 @@ extension NSObject {
         return token
     }
 
-    /**
-    Removes the closure observer with a certain identifier.
-
-    :param: token A unique key returned by observeKeyPath or the token given when creating the observer.
-    */
+    /// Removes the closure observer with a certain identifier.
+    ///
+    /// - parameter token: A unique key returned by observeKeyPath or the token given when creating the
+    ///                    observer.
     public func removeObserver(token: String) {
         if let keyPath = self.observer?.removeHandler(forToken: token)
             where self.observer?.hasObservers(forKeyPath: keyPath) == false
@@ -108,11 +104,9 @@ extension NSObject {
         }
     }
 
-    /**
-    Remove all registered closure observers for the given keyPath.
-
-    :param: keyPath The property to stop observing, relative to the reciever.
-    */
+    /// Remove all registered closure observers for the given keyPath.
+    ///
+    /// - parameter keyPath: The property to stop observing, relative to the reciever.
     public func removeAllObservers(forKeyPath keyPath: String? = nil) {
         guard let observer = self.observer else {
             return

--- a/Source/NSTimer+LambdaKit.swift
+++ b/Source/NSTimer+LambdaKit.swift
@@ -26,29 +26,25 @@ import Foundation
 
 public typealias LKTimerHandler = (timer: NSTimer) -> Void
 
-/**
-Simple closure implementation on NSTimer scheduling.
-
-Example:
-
-```swift
-NSTimer.scheduledTimerWithTimeInterval(1.0) { timer in
-println("Did something after 1s!")
-}
-```
-*/
+/// Simple closure implementation on NSTimer scheduling.
+///
+/// Example:
+///
+/// ```swift
+/// NSTimer.scheduledTimerWithTimeInterval(1.0) { timer in
+///     print("Did something after 1s!")
+/// }
+/// ```
 extension NSTimer {
 
-    /**
-    Creates and returns a block-based NSTimer object and schedules it on the current run loop.
-
-    - parameter interval:  The number of seconds between firings of the timer.
-    - parameter inRepeats: If true, the timer will repeatedly reschedule itself until invalidated. If false,
-                           the timer will be invalidated after it fires.
-    - parameter handler:   The closure that the NSTimer fires.
-
-    - returns: a new NSTimer object, configured according to the specified parameters.
-    */
+    /// Creates and returns a block-based NSTimer object and schedules it on the current run loop.
+    ///
+    /// - parameter interval:  The number of seconds between firings of the timer.
+    /// - parameter inRepeats: If true, the timer will repeatedly reschedule itself until invalidated. If
+    ///                        false, the timer will be invalidated after it fires.
+    /// - parameter handler:   The closure that the NSTimer fires.
+    ///
+    /// - returns: A new NSTimer object, configured according to the specified parameters.
     class public func scheduledTimerWithTimeInterval(interval: NSTimeInterval, repeated: Bool = false,
         handler: LKTimerHandler) -> NSTimer
     {

--- a/Source/UIBarButtonItem+LambdaKit.swift
+++ b/Source/UIBarButtonItem+LambdaKit.swift
@@ -30,17 +30,14 @@ public typealias LKBarButtonHandler = (sender: UIBarButtonItem) -> Void
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/** 
-Closure event initialization for UIBarButtonItem.
-
-Example:
-
-```swift
-self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: image, style: .Bordered) { btn in
-    println("Button touched!!!!!! \(btn)")
-}
-```
-*/
+/// Closure event initialization for UIBarButtonItem.
+///
+/// Example:
+/// ```swift
+/// self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: image, style: .Bordered) { btn in
+///     print("Button touched!!!!!! \(btn)")
+/// }
+/// ```
 extension UIBarButtonItem {
 
     private var closuresWrapper: ClosureWrapper? {
@@ -54,15 +51,13 @@ extension UIBarButtonItem {
         }
     }
 
-    /**
-    Initializes an UIBarButtonItem that will call the given closure when the button is touched.
-
-    - parameter image:   The item’s image. If nil an image is not displayed.
-    - parameter style:   The style of the item. One of the constants defined in UIBarButtonItemStyle.
-    - parameter handler: The closure which handles button touches.
-
-    - returns: an initialized instance of UIBarButtonItem.
-    */
+    /// Initializes an UIBarButtonItem that will call the given closure when the button is touched.
+    ///
+    /// - parameter image:   The item’s image. If nil an image is not displayed.
+    /// - parameter style:   The style of the item. One of the constants defined in UIBarButtonItemStyle.
+    /// - parameter handler: The closure which handles button touches.
+    ///
+    /// - returns: An initialized instance of UIBarButtonItem.
     public convenience init(image: UIImage?, style: UIBarButtonItemStyle, handler: LKBarButtonHandler) {
         self.init(image: image, style: style, target: nil, action: #selector(UIBarButtonItem.handleAction))
         self.closuresWrapper = ClosureWrapper(handler: handler)

--- a/Source/UIControl+LambdaKit.swift
+++ b/Source/UIControl+LambdaKit.swift
@@ -44,18 +44,16 @@ private final class ControlWrapper {
     }
 }
 
-/** 
-Closure control event handling for UIControl.
-
-Example:
-
-```swift
-let button = UIButton.buttonWithType(.System) as! UIButton
-button.addEventHandler(forControlEvents: .TouchUpInside) { button in
-    println("Button touched!!! \(button)")
-}
-```
-*/
+/// Closure control event handling for UIControl.
+///
+/// Example:
+///
+/// ```swift
+/// let button = UIButton.buttonWithType(.System) as! UIButton
+/// button.addEventHandler(forControlEvents: .TouchUpInside) { button in
+///     print("Button touched!!! \(button)")
+/// }
+/// ```
 extension UIControl {
 
     private var events: [UInt: [ControlWrapper]]? {
@@ -69,12 +67,11 @@ extension UIControl {
         }
     }
 
-    /** 
-    Adds a closure for a particular event to an internal dispatch table.
-
-    - parameter controlEvents: A bitmask specifying the control events for which the action message is sent.
-    - parameter handler: A block representing an action message, with an argument for the sender.
-    */
+    /// Adds a closure for a particular event to an internal dispatch table.
+    ///
+    /// - parameter controlEvents: A bitmask specifying the control events for which the action message is
+    ///                            sent.
+    /// - parameter handler:       A block representing an action message, with an argument for the sender.
     public func addEventHandler(forControlEvents controlEvents: UIControlEvents, handler: LKControlHandler) {
         let target = ControlWrapper(handler: handler, events: controlEvents)
         self.addTarget(target, action: #selector(ControlWrapper.invoke(_:)), forControlEvents: controlEvents)
@@ -88,11 +85,10 @@ extension UIControl {
         self.events = events
     }
 
-    /**
-    Remove *all* handlers for a given event.
-
-    - parameter controlEvents: A bitmask specifying the control events for which the handlers will be removed
-    */
+    /// Remove *all* handlers for a given event.
+    ///
+    /// - parameter controlEvents: A bitmask specifying the control events for which the handlers will be
+    ///                            removed.
     public func removeEventHandlers(forControlEvents controlEvents: UIControlEvents? = nil) {
         for (event, wrappers) in self.events ?? [:] {
             if controlEvents != nil && (event & controlEvents!.rawValue != controlEvents!.rawValue) {

--- a/Source/UIGestureRecognizer+LambdaKit.swift
+++ b/Source/UIGestureRecognizer+LambdaKit.swift
@@ -29,19 +29,17 @@ public typealias LKGestureHandler = (sender: UIGestureRecognizer, state: UIGestu
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-Closure functionality for UIGestureRecognizer.
-
-Example: 
-
-```swift
-let doubleTap = UITapGestureRecognizer { gesture, state in
-    println("Double tap!")
-}
-doubleTap.numberOfTapsRequired = 2
-self.addGestureRecognizer(doubleTap)
-```
-*/
+/// Closure functionality for UIGestureRecognizer.
+///
+/// Example:
+///
+/// ```swift
+/// let doubleTap = UITapGestureRecognizer { gesture, state in
+///     print("Double tap!")
+/// }
+/// doubleTap.numberOfTapsRequired = 2
+/// self.addGestureRecognizer(doubleTap)
+/// ```
 extension UIGestureRecognizer {
 
     private var closureWrapper: GestureClosureWrapper? {
@@ -55,16 +53,12 @@ extension UIGestureRecognizer {
         }
     }
 
-    /**
-    Initializes an allocated gesture recognizer that will call the given closure when the gesture is 
-    recognized.
-
-    An alternative to the designated initializer.
-
-    - parameter handler: The closure which handles an executed gesture.
-
-    - returns: an initialized instance of a concrete UIGestureRecognizer subclass.
-    */
+    /// Initializes an allocated gesture recognizer that will call the given closure when the gesture is
+    /// recognized.  An alternative to the designated initializer.
+    ///
+    /// - parameter handler: The closure which handles an executed gesture.
+    ///
+    /// - returns: An initialized instance of a concrete UIGestureRecognizer subclass.
     public convenience init(handler: LKGestureHandler) {
         self.init()
 

--- a/Source/UIImagePickerController+LambdaKit.swift
+++ b/Source/UIImagePickerController+LambdaKit.swift
@@ -31,22 +31,20 @@ public typealias LKCancelClosure = (UIImagePickerController) -> Void
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-UIImagePickerController with closure callback(s).
-
-Example:
-
-```swift
-let picker = UIImagePickerController()
-picker.didCancel = { picker in
-    println("DID CANCEL! \(picker)")
-}
-picker.didFinishPickingMedia = { picker, media in 
-    println("Media: \(media[UIImagePickerControllerEditedImage])")
-}
-self.presentViewController(picker, animated: true, completion: nil)
-```
-*/
+/// UIImagePickerController with closure callback(s).
+///
+/// Example:
+///
+/// ```swift
+/// let picker = UIImagePickerController()
+/// picker.didCancel = { picker in
+///     print("DID CANCEL! \(picker)")
+/// }
+/// picker.didFinishPickingMedia = { picker, media in
+///     print("Media: \(media[UIImagePickerControllerEditedImage])")
+/// }
+/// self.presentViewController(picker, animated: true, completion: nil)
+/// ```
 extension UIImagePickerController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
 
     private var closuresWrapper: ClosuresWrapper {

--- a/Source/UIWebView+LambdaKit.swift
+++ b/Source/UIWebView+LambdaKit.swift
@@ -28,7 +28,7 @@ import UIKit
 public typealias LKShouldStartClosure = (UIWebView, NSURLRequest, UIWebViewNavigationType) -> Bool
 public typealias LKDidStartClosure = (UIWebView) -> Void
 public typealias LKDidFinishLoadClosure = (UIWebView) -> Void
-public typealias LKDidFinishWithErrorClosure = (UIWebView, NSError?) -> Void
+public typealias LKDidFinishWithErrorClosure = (UIWebView, NSError) -> Void
 
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
@@ -121,7 +121,7 @@ extension UIWebView: UIWebViewDelegate {
         self.didFinishLoad?(webView)
     }
 
-    public func webView(webView: UIWebView, didFailLoadWithError error: NSError?) {
+    public func webView(webView: UIWebView, didFailLoadWithError error: NSError) {
         self.didFinishWithError?(webView, error)
     }
 }

--- a/Source/UIWebView+LambdaKit.swift
+++ b/Source/UIWebView+LambdaKit.swift
@@ -33,34 +33,31 @@ public typealias LKDidFinishWithErrorClosure = (UIWebView, NSError) -> Void
 // A global var to produce a unique address for the assoc object handle
 private var associatedEventHandle: UInt8 = 0
 
-/**
-Closure support for UIWebView.
-
-Example:
-
-```swift
-let webView = UIWebView()
-webView.shouldStartLoad = { webView, request, type in
-    println("shouldStartLoad: \(request)")
-    return true
-}
-
-webView.didStartLoad = { webView in
-    println("didStartLoad: \(webView)")
-}
-
-webView.didFinishLoad = { webView in
-    println("didFinishLoad \(webView)")
-}
-
-webView.didFinishWithError = { webView, error in
-    println("didFinishWithError \(error)")
-}
-```
-
-WARNING: You cannot use closures *and* set a delegate at the same time. Setting a delegate will prevent
-closures for being called and setting a closure will overwrite the delegate property.
-*/
+/// Closure support for UIWebView.
+///
+/// Example:
+///
+/// ```swift
+/// let webView = UIWebView() webView.shouldStartLoad = { webView, request, type in
+///     print("shouldStartLoad: \(request)")
+///     return true
+/// }
+///
+/// webView.didStartLoad = { webView in
+///     print("didStartLoad: \(webView)")
+/// }
+///
+/// webView.didFinishLoad = { webView in
+///     print("didFinishLoad \(webView)")
+/// }
+///
+/// webView.didFinishWithError = { webView, error in
+///     print("didFinishWithError \(error)")
+/// }
+/// ```
+///
+/// WARNING: You cannot use closures *and* set a delegate at the same time. Setting a delegate will prevent
+/// closures for being called and setting a closure will overwrite the delegate property.
 extension UIWebView: UIWebViewDelegate {
 
     private var closuresWrapper: ClosuresWrapper {


### PR DESCRIPTION
- Avoids a warning about not conforming to a protocol-required method
- Adds the now required `locationManager(_:didFailWithError:)` method that can be used by consumers of the API
