### PR TITLE
Fix Swift beta number warnings

### DIFF
--- a/Source/CADisplayLink+LambdaKit.swift
+++ b/Source/CADisplayLink+LambdaKit.swift
@@ -71,7 +71,7 @@ extension CADisplayLink {
             return
         }
 
-        if closureWrapper.startTime < DBL_EPSILON {
+        if closureWrapper.startTime < .ulpOfOne {
             displayLink.closureWrapper?.startTime = displayLink.timestamp
         }
 


### PR DESCRIPTION
Usage of DBL_EPSILON is deprecated in Swift 3.1 to be removed in Swift
4. The replacement was in Swift 3 so we can go ahead and migrate.