### PR TITLE
Bump Minimal Supported watchOS Version

### DIFF
--- a/LambdaKit.podspec
+++ b/LambdaKit.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/Reflejo/LambdaKit.git', :tag => s.version }
 
   s.ios.deployment_target = '8.0'
-  s.watchos.deployment_target = '2.0'
+  s.watchos.deployment_target = '3.0'
 
   s.ios.source_files = 'Source/*.swift'
   s.watchos.source_files = 'Source/NSObject*.swift', 'Source/CLLocationManager*.swift'

--- a/Source/CLLocationManager+LambdaKit.swift
+++ b/Source/CLLocationManager+LambdaKit.swift
@@ -91,7 +91,7 @@ extension CLLocationManager: CLLocationManagerDelegate {
     /// Request the current location which is reported in the completion handler.
     ///
     /// - parameter completion: A closure that will be called with the device's current location.
-    @available(iOS 9, watchOS 2, *)
+    @available(iOS 9, *)
     public func requestLocation(_ completion: @escaping LKCoreLocationHandler) {
         self.closureWrapper = ClosureWrapper(handler: completion)
         self.delegate = self


### PR DESCRIPTION
We use an [API][API] that only [available][doc] on watchOS 3+. So we shouldn't
claim support for 2.0.

[API]: https://github.com/Reflejo/LambdaKit/blob/master/Source/CLLocationManager+LambdaKit.swift#L78
[doc]: https://developer.apple.com/documentation/corelocation/cllocationmanager/1423750-startupdatinglocation