### PR TITLE
Add @discardableResult to CADisplayLink extension

### DIFF
--- a/Source/CADisplayLink+LambdaKit.swift
+++ b/Source/CADisplayLink+LambdaKit.swift
@@ -62,6 +62,7 @@ extension CADisplayLink {
     ///
     /// - parameter duration: The duration in seconds.
     /// - parameter handler:  The closure to execute for every tick.
+    @discardableResult
     public static func runFor(_ duration: CFTimeInterval,
                               handler: @escaping LKDisplayLinkClosure) -> CADisplayLink
     {


### PR DESCRIPTION
Since we invalidate the display link when the run duration is completed,
you don't need to hold on to it in all cases.