### PR TITLE
[WKWebView] Make navigation properties optional

### DIFF
--- a/Sources/LambdaKit/WKWebView+LambdaKit.swift
+++ b/Sources/LambdaKit/WKWebView+LambdaKit.swift
@@ -35,12 +35,12 @@ public typealias LKDecidePolicyForAction =
     (WKWebView, WKNavigationAction, ((WKNavigationActionPolicy) -> Void)) -> Void
 public typealias LKDecidePolicyForResponse =
     (WKWebView, WKNavigationResponse, ((WKNavigationResponsePolicy) -> Void)) -> Void
-public typealias LKDidStartProvisionalNavigation = (WKWebView, WKNavigation) -> Void
-public typealias LKDidReceiveServerRedirectForProvisionalNavigation = (WKWebView, WKNavigation) -> Void
-public typealias LKDidFailProvisionalNavigation = (WKWebView, WKNavigation, Error) -> Void
-public typealias LKDidCommit = (WKWebView, WKNavigation) -> Void
-public typealias LKDidFinish = (WKWebView, WKNavigation) -> Void
-public typealias LKDidFail = (WKWebView, WKNavigation, Error) -> Void
+public typealias LKDidStartProvisionalNavigation = (WKWebView, WKNavigation?) -> Void
+public typealias LKDidReceiveServerRedirectForProvisionalNavigation = (WKWebView, WKNavigation?) -> Void
+public typealias LKDidFailProvisionalNavigation = (WKWebView, WKNavigation?, Error) -> Void
+public typealias LKDidCommit = (WKWebView, WKNavigation?) -> Void
+public typealias LKDidFinish = (WKWebView, WKNavigation?) -> Void
+public typealias LKDidFail = (WKWebView, WKNavigation?, Error) -> Void
 public typealias LKDidReceiveChallenge =
     (WKWebView, URLAuthenticationChallenge, ((URLSession.AuthChallengeDisposition, URLCredential?) -> Void))
     -> Void


### PR DESCRIPTION
## Description
Apparently, based on bug reports, the delegate methods do not guarantee to get the navigation object, so we are updating the block properties from non-optional to optional for stability.