### PR TITLE
Update for Swift 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode10.2
 
 install: true
 script:

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,11 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
     name: "LambdaKit",
-    targets: [.target(name: "LambdaKit")],
-    swiftLanguageVersions: [.v4_2]
+    platforms: [
+        .iOS(.v10),
+        .watchOS(.v3),
+    ],
+    targets: [.target(name: "LambdaKit")]
 )

--- a/settings.xcconfig
+++ b/settings.xcconfig
@@ -13,7 +13,6 @@ APPLICATION_EXTENSION_API_ONLY = YES
 
 // The base SDK to use (if no version is specified, the latest is assumed)
 SDKROOT = iphoneos
-IPHONEOS_DEPLOYMENT_TARGET = 10.0
 
 // Supported device families (1 is iPhone, 2 is iPad)
 SUPPORTED_PLATFORMS = iphonesimulator iphoneos


### PR DESCRIPTION
No source changes are necessary. The Package.swift platforms addition is
required otherwise the generated xcodeproj defaults to a deployment
target of 8.0, which had a higher precedence than our xcconfig