### PR TITLE
MFMessageComposeViewController completion after dismissal animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,18 @@ composerViewController.setSubject("Test")
 
 MFMessageComposeViewController with closure callback.
 
-Note that when setting a completion handler, you don't have the responsability to dismiss the view controller
+Note that when setting a completion handler, you don't have the responsibility to dismiss the view controller
 anymore.
 
 ```swift
 let composeViewController = MFMessageComposeViewController { viewController, result in println("Done") }
+composerViewController.body = "test sms"
+```
+
+Set completionAfterDismissal to true if you want the completion handler to be invoked after the controller dismissal animation has been completed.
+
+```
+let composeViewController = MFMessageComposeViewController(completionAfterDismissal: true) { viewController, result in println("Done") }
 composerViewController.body = "test sms"
 ```
 

--- a/Sources/LambdaKit/MFMessageComposeViewController+LambdaKit.swift
+++ b/Sources/LambdaKit/MFMessageComposeViewController+LambdaKit.swift
@@ -76,7 +76,8 @@ extension MFMessageComposeViewController: MFMessageComposeViewControllerDelegate
     ///                                       after the controller has been dismissed.
     /// - parameter completion:               A closure analog to
     ///                                       messageComposeViewController:didFinishWithResult:.
-    ///                                       Invoked immediately after dismissing the controller.
+    ///                                       If completionAfterDismissal = true, this is invoked after the dismissal animation has completed.
+    ///                                       If completionAfterDismissal is false, this is invoked immediately after the call to dismiss the controller.
     ///
     /// - returns: An initialized instance of MFMessageComposeViewController.
     public convenience init(


### PR DESCRIPTION
When using the completion block of MFMessageComposeViewController, sometimes the caller wants to wait until the controller dismissal animation has been completed.

This change adds an optional Bool to allow waiting until after the dismissal animation before invoking the completion block.